### PR TITLE
Support passing tags as js object

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,113 +12,201 @@ npm install @uswriting/exiftool
 
 This package provides a WebAssembly-based implementation of ExifTool that works in both browser and Node.js environments. It leverages [zeroperl](https://github.com/uswriting/zeroperl) to execute ExifTool without requiring any native binaries or system dependencies.
 
-## Usage
+## Writing Metadata with `writeMetadata`
+**[Sample website `exiftool-write-test` to demonstrate usage](https://github.com/vaibhavshirole/LivePhotoBridge/tree/main/exiftool-write-test)**
 
-### Basic Usage
+This fork includes a `writeMetadata` function to modify metadata in files using ExifTool, running entirely client-side via WebAssembly. 
+It works by creating a *new* file in memory with the specified metadata changes applied.
 
-```typescript
-import { parseMetadata } from '@uswriting/exiftool';
 
-// Browser usage with File API
-document.querySelector('input[type="file"]').addEventListener('change', async (event) => {
-  const file = event.target.files[0];
-  const result = await parseMetadata(file);
-  
-  if (result.success) {
-    console.log(result.data);
-  } else {
-    console.error('Error:', result.error);
-  }
-});
-```
-
-### Extracting Specific Metadata
+**Synopsis:**
 
 ```typescript
-import { parseMetadata } from '@uswriting/exiftool';
+import { writeMetadata, ExifToolWriteOptions, ExifToolWriteResult, Binaryfile } from '@uswriting/exiftool';
 
-const result = await parseMetadata(file, {
-  args: ['-Author', '-CreateDate', '-Make', '-Model']
-});
-
-if (result.success) {
-  console.log(result.data);
-}
-```
-
-### JSON Output
-
-```typescript
-import { parseMetadata } from '@uswriting/exiftool';
-
-const result = await parseMetadata(file, {
-  args: ['-json', '-n'],
-  transform: (data) => JSON.parse(data)
-});
-
-if (result.success) {
-  // Typed access to properties
-  console.log(result.data); // { ... }
-}
-```
-
-## Important Notes
-
-- In browser environments, pass the `File` object directly from file inputs. Do not convert it to an ArrayBuffer or Uint8Array.
-- This package uses asynchronous web APIs for file processing which allows handling files over 2GB without loading them entirely into memory.
-- ExifTool is executed entirely within the browser or Node.js environment - no server requests are made for metadata extraction.
-
-## API Reference
-
-### parseMetadata()
-
-```typescript
-async function parseMetadata<TReturn = string>(
+async function writeMetadata(
   file: Binaryfile | File,
-  options: ExifToolOptions<TReturn> = {}
-): Promise<ExifToolOutput<TReturn>>
+  options: ExifToolWriteOptions
+): Promise<ExifToolWriteResult>
 ```
 
-#### Parameters
+**How it Works Internally:**
 
-- `file`: Either a browser `File` object or a `Binaryfile` object with `name` and `data` properties.
-- `options`: Configuration options for the metadata extraction.
+The function performs these steps:
 
-#### Options
+1.  Creates a temporary in-memory virtual filesystem (using WASI `MemoryFileSystem`).
+2.  Loads the provided input `file` data into this virtual filesystem (e.g., at `/source_image.jpg`).
+3.  Loads the ExifTool perl script and the optional `configFile` into the virtual filesystem.
+4.  Constructs ExifTool command-line arguments including:
+    *   Tag assignments specified in `options.tags` (e.g., `-Comment=New`).
+    *   The `-o /output_image.jpg` flag, instructing ExifTool to write the result to a *new* file within the virtual filesystem.
+    *   The path to the input file in the virtual filesystem (e.g., `/source_image.jpg`).
+    *   **Note:** It does *not* use `-overwrite_original`.
+5.  Sets the `EXIFTOOL_CONFIG` environment variable if `options.configFile` is provided.
+6.  Executes ExifTool via the `zeroperl.wasm` runtime within the configured WASI environment.
+7.  If ExifTool exits successfully (code 0), it retrieves the binary data of the *output file* (e.g., `/output_image.jpg`) from the virtual filesystem.
+8.  Returns the result, including the binary data of the newly created file with modified metadata.
+
+**Parameters:**
+
+*   `file`: (`File | Binaryfile`)
+    *   The input file containing the original metadata. This can be a standard browser `File` object (from an `<input type="file">`) or a `Binaryfile` object (`{ name: string; data: Uint8Array | Blob }`).
+    *   **This original file object is NOT modified.**
+*   `options`: (`ExifToolWriteOptions`)
+    *   An object containing configuration for the write operation:
+    *   `tags`: (`string[]`) - **Required**. An array of strings, where each string is a complete ExifTool tag assignment argument.
+        *   Examples: `"-Comment=My Description"`, `"-Artist=John Doe"`, `"-XMP-dc:Subject=Testing"`, `"-GPSLatitudeRef=N"`, `"-AllDates-=1:0:0"`
+    *   `configFile` (`{ name: string; data: Uint8Array }`) - **Optional, but required for custom tags**. An object containing:
+        *   `name`: The desired filename for the config file within the virtual filesystem (e.g., `"my.config"`).
+        *   `data`: The binary content (`Uint8Array`) of the ExifTool configuration file. This file *must* define any custom tags (like `XMP-GCamera`) you intend to write. You typically need to fetch this file's content first.
+    *   `extraArgs` (`string[]`) - **Optional**. An array of additional ExifTool command-line flags (e.g., `["-m", "-q"]` to ignore minor errors and run quietly). Do not include `-config`, `-o`, overwrite_original`, input/output filenames, or tag assignments here.
+    *   `fetch` (`FetchLike`) - **Optional**. A custom `fetch`-compatible function, usually only needed in specific non-browser environments. Defaults to the global `fetch`.
+
+**Return Value:**
+
+*   `Promise<ExifToolWriteResult>`: A Promise that resolves to an object describing the outcome:
+    *   On **Success**:
+        ```typescript
+        {
+          success: true;
+          data: Uint8Array; // The binary data of the NEW file with modified metadata
+          warnings: string;  // Any warning messages from ExifTool's stderr output
+          exitCode: 0;
+        }
+        ```
+    *   On **Failure**:
+        ```typescript
+        {
+          success: false;
+          data: undefined;
+          error: string;     // Error message (usually from ExifTool stderr or internal error)
+          exitCode: number | undefined; // ExifTool's non-zero exit code, or undefined if Wasm failed before exit
+        }
+        ```
+
+**Prerequisites:**
+
+*   The `zeroperl.wasm` runtime must be accessible (typically via the default CDN URL or fetched).
+*   If writing custom/user-defined tags, you **must** provide the corresponding ExifTool configuration file via the `options.configFile` parameter.
+
+**Usage Examples:**
+
+**1. Writing Standard Tags (e.g., Comment, Author)**
 
 ```typescript
-interface ExifToolOptions<TReturn> {
-  // Additional command-line arguments to pass to ExifTool
-  args?: string[];
-  
-  // Custom fetch implementation for loading the WASM module
-  fetch?: (...args: any[]) => Promise<Response>;
-  
-  // Transform the raw ExifTool output into a different format
-  transform?: (data: string) => TReturn;
+// Assuming 'selectedFile' is a File object from an <input>
+// and 'writeMetadata' is imported.
+
+async function handleWriteStandardTags() {
+  if (!selectedFile) return;
+
+  const tagsToWrite = [
+    `-Comment=Processed on ${new Date().toISOString()}`,
+    "-Author=Vaibhav",
+    "-Copyright=2025"
+  ];
+
+  const options: ExifToolWriteOptions = {
+    tags: tagsToWrite,
+    extraArgs: ["-m"] // Ignore minor errors
+  };
+
+  statusDiv.textContent = "Writing standard tags..."; // Update UI
+
+  try {
+    const result = await writeMetadata(selectedFile, options);
+
+    if (result.success) {
+      statusDiv.textContent = `Success! Warnings: ${result.warnings || 'None'}`;
+      console.log("Modified data size:", result.data.byteLength);
+
+      // Create a downloadable Blob from the NEW file data
+      const blob = new Blob([result.data], { type: selectedFile.type });
+      const url = URL.createObjectURL(blob);
+      // Offer download link (logic depends on your UI framework)
+      // setupDownloadLink(url, `modified_${selectedFile.name}`);
+
+    } else {
+      statusDiv.textContent = `Error writing tags: ${result.error} (Code: ${result.exitCode})`;
+      console.error("Write failed:", result);
+    }
+  } catch (error) {
+      const message = (error instanceof Error) ? error.message : String(error);
+      statusDiv.textContent = `JavaScript Error: ${message}`;
+      console.error("Error calling writeMetadata:", error);
+  }
 }
 ```
 
-#### Return Value
-
-Returns a Promise that resolves to an `ExifToolOutput` object:
+**2. Writing Custom XMP Tags (e.g., XMP-GCamera)**
 
 ```typescript
-type ExifToolOutput<TOutput> =
-  | {
-      success: true;
-      data: TOutput;
-      error: string;
-      exitCode: 0;
+// Assuming 'selectedFile' is a File object, 'writeMetadata' is imported,
+// and you have a 'google.config' file in your web server's public directory.
+
+// Helper to fetch the config file
+async function loadConfigFile(url: string): Promise<{ name: string; data: Uint8Array } | undefined> {
+  try {
+      const response = await fetch(url);
+      if (!response.ok) throw new Error(`HTTP error! status: ${response.status} for ${url}`);
+      const arrayBuffer = await response.arrayBuffer();
+      const fileName = url.substring(url.lastIndexOf('/') + 1);
+      return { name: fileName, data: new Uint8Array(arrayBuffer) };
+  } catch (e) {
+      console.error(`Failed to load config file from ${url}:`, e);
+      return undefined;
+  }
+}
+
+async function handleWriteGCameraTags() {
+  if (!selectedFile) return;
+
+  statusDiv.textContent = "Loading config file...";
+  const configFileContent = await loadConfigFile('/google.config'); // Adjust path if needed
+
+  if (!configFileContent) {
+      statusDiv.textContent = 'Error: Could not load google.config. Required for custom tags.';
+      return;
+  }
+
+  statusDiv.textContent = "Config loaded. Writing GCamera tags...";
+
+  // Example GCamera tags
+  const dummyOffset = 123456;
+  const dummyTimestamp = 98765;
+  const tagsToWrite = [
+    "-XMP-GCamera:MicroVideo=1",
+    "-XMP-GCamera:MicroVideoVersion=1",
+    `-XMP-GCamera:MicroVideoOffset=${dummyOffset}`,
+    `-XMP-GCamera:MicroVideoPresentationTimestampUs=${dummyTimestamp}`,
+  ];
+
+  const options: ExifToolWriteOptions = {
+    tags: tagsToWrite,
+    configFile: configFileContent, // Provide the loaded config file!
+    extraArgs: ["-m", "-q"]
+  };
+
+  try {
+    const result = await writeMetadata(selectedFile, options);
+
+    if (result.success) {
+      statusDiv.textContent = `Success! GCamera tags written. Warnings: ${result.warnings || 'None'}`;
+      console.log("Modified data size:", result.data.byteLength);
+
+      // Offer download
+      const blob = new Blob([result.data], { type: selectedFile.type });
+      const url = URL.createObjectURL(blob);
+      // setupDownloadLink(url, `gcam_modified_${selectedFile.name}`);
+
+    } else {
+      statusDiv.textContent = `Error writing GCamera tags: ${result.error} (Code: ${result.exitCode})`;
+      console.error("Write failed:", result);
     }
-  | {
-      success: false;
-      data: undefined;
-      error: string;
-      exitCode: number | undefined;
-    };
+  } catch (error) {
+      const message = (error instanceof Error) ? error.message : String(error);
+      statusDiv.textContent = `JavaScript Error: ${message}`;
+      console.error("Error calling writeMetadata:", error);
+  }
+}
 ```
-
-## License
-
-Apache License, Version 2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "@uswriting/exiftool",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uswriting/exiftool",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@uswriting/exiftool": "^1.0.3"
+      },
       "devDependencies": {
         "esbuild": "^0.25.0",
         "esbuild-raw-plugin": "^0.1.1",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -438,6 +441,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@uswriting/exiftool": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@uswriting/exiftool/-/exiftool-1.0.3.tgz",
+      "integrity": "sha512-dw6LOo7GnG65I9fCCVbsensRaQrATvBhRhuFQsMl21JPB9CCJWrArD4/BaRQkftrjOXLVJ9qqp6/XSgcRKfnkQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/esbuild": {
       "version": "0.25.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "devDependencies": {
     "esbuild": "^0.25.0",
     "esbuild-raw-plugin": "^0.1.1",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
+  },
+  "dependencies": {
+    "@uswriting/exiftool": "^1.0.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import exiftool from "./ex";
+import exiftoolRaw from "./ex"; // Import the raw string content
 import { MemoryFileSystem, useMemoryFS } from "./wasi/features/fd";
 import {
   useArgs,
@@ -7,6 +8,7 @@ import {
   useProc,
   useRandom,
   WASI,
+  WASIProcExit,
 } from "./wasi";
 import { instantiateStreaming } from "./wasi/asyncify";
 import { WASIOptions } from "./wasi/options";
@@ -14,12 +16,13 @@ import { StringBuilder } from "./sb";
 
 const cdn = "https://perl.objex.ai/zeroperl-1.0.0.wasm";
 type FetchLike = (...args: any[]) => Promise<Response>;
+const textDecoder = new TextDecoder();
 
 /**
  * Configuration options for parsing file metadata with ExifTool
  * @template TReturn The type of the transformed output data
  */
-export interface ExifToolOptions<TReturn> {
+interface ExifToolOptions<TReturn> {
   /**
    * Additional command-line arguments to pass to ExifTool
    *
@@ -51,8 +54,6 @@ export interface ExifToolOptions<TReturn> {
    */
   transform?: (data: string) => TReturn;
 }
-
-const textDecoder = new TextDecoder();
 
 /**
  * Represents a binary file for metadata extraction
@@ -91,6 +92,73 @@ type ExifToolOutput<TOutput> =
     };
 
 /**
+ * Configuration options for writing file metadata with ExifTool
+ */
+interface ExifToolWriteOptions {
+  /**
+   * An array of tag assignment arguments to pass to ExifTool.
+   * Each string should be in the format "-TAG=VALUE" or "-TAG<=VALUE".
+   *
+   * @example
+   * tags: [
+   *   "-XMP-GCamera:MicroVideo=1",
+   *   "-XMP-GCamera:MicroVideoOffset=50000",
+   *   "-Comment=Processed by Web App"
+   * ]
+   * @see https://exiftool.org/exiftool_pod.html#Writing-Meta-Information
+   */
+  tags: string[];
+
+  /**
+   * Optional: Provide a custom ExifTool config file as binary data.
+   * Necessary for defining custom tags like XMP-GCamera.
+   */
+  configFile?: {
+    /** Filename for the config file within the virtual environment (e.g., "my.config") */
+    name: string;
+    /** The binary content of the config file */
+    data: Uint8Array;
+  };
+
+  /**
+   * Custom fetch implementation (same as parseMetadata)
+   */
+  fetch?: FetchLike;
+
+  /**
+   * Addtional arguments *other* than tag assignments (e.g. -m, -q).
+   * '-overwrite_original' is added automatically.
+   * Avoid adding input/output filenames or tag assignments here.
+   */
+   extraArgs?: string[];
+}
+
+/**
+ * Result of an ExifTool metadata writing operation
+ */
+type ExifToolWriteResult =
+  | {
+      /** True when metadata was successfully written */
+      success: true;
+      /** The binary data of the modified file */
+      data: Uint8Array;
+      /** Any warnings or info messages from ExifTool (stderr) */
+      warnings: string;
+      /** Always 0 for success */
+      exitCode: 0;
+    }
+  | {
+      /** False when metadata writing failed */
+      success: false;
+      /** No data available on failure */
+      data: undefined;
+      /** Error message explaining why the operation failed (stderr) */
+      error: string;
+      /** Non-zero exit code indicating the type of failure */
+      exitCode: number | undefined;
+    };
+
+/**
  * Extract metadata from a file using ExifTool
  *
  * @template TReturn Type of the returned data after transformation (defaults to string)
@@ -119,7 +187,7 @@ type ExifToolOutput<TOutput> =
  *   console.log(result.data); // Typed access to specific metadata
  * }
  */
-export async function parseMetadata<TReturn = string>(
+async function parseMetadata<TReturn = string>(
   file: Binaryfile | File,
   options: ExifToolOptions<TReturn> = {}
 ): Promise<ExifToolOutput<TReturn>> {
@@ -202,3 +270,204 @@ export async function parseMetadata<TReturn = string>(
     exitCode,
   };
 }
+
+/**
+ * Writes metadata to a file using ExifTool in Wasm.
+ *
+ * @param file The file to modify (as a browser File or a BinaryFile object).
+ * @param options Configuration options including the tags to write.
+ * @returns Promise resolving to the write result, containing the modified file data on success.
+ *
+ * @example
+ * // Assuming 'jpegFile' is a File object and 'configData' is a Uint8Array of the config file
+ * const result = await writeMetadata(jpegFile, {
+ *   tags: [
+ *     "-XMP-GCamera:MicroVideo=1",
+ *     "-XMP-GCamera:MicroVideoOffset=123456",
+ *     "-XMP-GCamera:MicroVideoPresentationTimestampUs=0"
+ *   ],
+ *   configFile: { name: "google.config", data: configData },
+ *   extraArgs: ["-m", "-q"] // Ignore minor errors, be quiet
+ * });
+ *
+ * if (result.success) {
+ *   // result.data contains the Uint8Array of the modified file
+ *   const blob = new Blob([result.data], { type: jpegFile.type });
+ *   // Now you can offer the blob for download
+ *   console.log("Metadata written successfully!");
+ * } else {
+ *   console.error("Error writing metadata:", result.error);
+ * }
+ */
+async function writeMetadata(
+  file: Binaryfile | File,
+  options: ExifToolWriteOptions
+): Promise<ExifToolWriteResult> {
+
+  // 1. Initialize MemoryFileSystem
+  const fileSystem = new MemoryFileSystem({ "/": "" });
+
+  // 2. Prepare and add ExifTool script data
+  let exiftoolData: Uint8Array;
+  if (typeof exiftoolRaw === 'string') {
+    exiftoolData = new TextEncoder().encode(exiftoolRaw);
+  } else {
+      console.error("Unexpected type for imported exiftool script data:", typeof exiftoolRaw);
+      return { success: false, data: undefined, error: "Internal error: ExifTool script data is not a string.", exitCode: undefined };
+  }
+  fileSystem.addFile("/exiftool", exiftoolData);
+
+  // 3. Prepare and add the input file data
+  const inputFilename = file instanceof File ? file.name : file.name;
+  const sanitizedInputFilename = inputFilename.replace(/[^a-zA-Z0-9._-]/g, '_');
+  // Define distinct input and output paths in the virtual FS
+  const inputFilePath = `/source_${sanitizedInputFilename}`; // e.g., /source_image.jpg
+  const outputFilePath = `/output_${sanitizedInputFilename}`; // e.g., /output_image.jpg
+
+  const fileData = file instanceof File ? new Uint8Array(await file.arrayBuffer()) : file.data;
+  if (!(fileData instanceof Uint8Array) && !(fileData instanceof Blob)) {
+      return { success: false, data: undefined, error: "Input file data must be Uint8Array or Blob.", exitCode: undefined };
+  }
+  fileSystem.addFile(inputFilePath, fileData); // Add the input file
+
+  // 4. Add the config file to virtual FS (if provided)
+  let configFilePath: string | undefined; // Still need the path
+  if (options.configFile) {
+    if (!(options.configFile.data instanceof Uint8Array)) {
+       return { success: false, data: undefined, error: "Config file data must be Uint8Array.", exitCode: undefined };
+    }
+    configFilePath = `/${options.configFile.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+    fileSystem.addFile(configFilePath, options.configFile.data);
+  } else {
+    // If custom tags are used, a config file is mandatory
+    // Add a check here if your logic depends on the config file always being present for certain tags
+    console.warn("Writing custom XMP tags but no config file provided. This might fail if tags are undefined.");
+    // Optionally return an error:
+    // return { success: false, data: undefined, error: "Config file required for custom tags.", exitCode: undefined };
+  }
+
+  // 5. Construct the command-line arguments for writing
+  const exiftoolArgs = ["zeroperl", "exiftool"]; // Base command
+
+  // --- DO NOT ADD -config TO ARGUMENTS ---
+  // if (configFilePath) {
+  //   exiftoolArgs.push("-config");
+  //   exiftoolArgs.push(configFilePath);
+  // }
+
+  // --- Add other arguments ---
+  exiftoolArgs.push(...(options.extraArgs || []));
+  exiftoolArgs.push(...options.tags);
+  exiftoolArgs.push("-o", outputFilePath);
+  exiftoolArgs.push(inputFilePath);
+
+  // 6. Setup WASI environment
+  const stderr = new StringBuilder();
+
+  // --- Define the environment variables ---
+  const wasiEnv = {
+    LC_ALL: "C",
+    PERL_UNICODE: "SAD",
+    // --- ADD EXIFTOOL_CONFIG if config file exists ---
+    ...(configFilePath && { EXIFTOOL_CONFIG: configFilePath })
+  };
+  // --- Log the environment being passed ---
+  console.log("[DEBUG] WASI Environment:", wasiEnv);
+
+  const wasiOptions: WASIOptions = {
+    env: wasiEnv, // Pass the constructed environment
+    args: exiftoolArgs,
+    features: [
+      useEnviron, // Make sure useEnviron is included to process the env object
+      useArgs, useRandom, useClock, useProc,
+      useMemoryFS({
+        withFileSystem: fileSystem,
+        withStdIo: { stderr: (str) => { /* capture stderr */
+             if (ArrayBuffer.isView(str)) str = textDecoder.decode(str);
+             if (StringBuilder.isMultiline(str)) stderr.append(str); else stderr.appendLine(str);
+         }, stdout: () => {} }
+      })
+    ]
+  };
+  const wasi = new WASI(wasiOptions); // Pass the full options here
+
+  // 7. Fetch and instantiate Wasm (same as before)
+  const f = options.fetch ?? fetch;
+  let instance: WebAssembly.Instance;
+  try {
+      instance = (await instantiateStreaming(f(cdn), { wasi_snapshot_preview1: wasi.wasiImport })).instance;
+  } catch (err) {
+      const message = (err instanceof Error) ? err.message : String(err);
+      return { success: false, data: undefined, error: `Wasm instantiation failed: ${message}`, exitCode: undefined };
+  }
+
+  // 8. Run the Wasm process (same as before)
+  let exitCode: number | undefined;
+  let runError: Error | WASIProcExit | unknown | undefined;
+  try {
+      exitCode = await wasi.start(instance);
+  } catch (err) {
+      runError = err;
+      if (err instanceof WASIProcExit) exitCode = err.code;
+      else exitCode = undefined; // Unknown exit code on other errors
+  }
+
+  const stderrOutput = stderr.toString();
+
+  // 9. Check exit code and handle errors (same as before)
+  if (exitCode !== 0) {
+      let errorMsg = stderrOutput;
+      if (!errorMsg) {
+          if (runError && !(runError instanceof WASIProcExit)) {
+               const message = (runError instanceof Error) ? runError.message : String(runError);
+               errorMsg = `WASI start failed: ${message}`;
+          } else { errorMsg = `ExifTool exited with code ${exitCode}`; }
+      }
+      console.error(`ExifTool process failed. Exit code: ${exitCode}. Stderr:\n${stderrOutput}`);
+      return { success: false, data: undefined, error: errorMsg, exitCode };
+  }
+
+  // 10. Retrieve the *output* file data from the virtual filesystem
+  let modifiedFileData: Uint8Array | undefined;
+  try {
+      // --- Lookup the DEFINED OUTPUT PATH ---
+      const node = fileSystem.lookup(outputFilePath);
+
+      if (!node) {
+          // If exiftool succeeded (exit 0) but output file doesn't exist, something is wrong.
+          throw new Error(`Output file node not found at path: ${outputFilePath} despite exit code 0.`);
+      } else if (node.type !== 'file') {
+          throw new Error(`Output node at path ${outputFilePath} is not a file (type: ${node.type})`);
+      } else {
+          const fileContent = node.content;
+          if (fileContent instanceof Uint8Array) {
+              modifiedFileData = fileContent;
+          } else if (fileContent instanceof Blob) {
+              console.log("[DEBUG] Retrieved output file content as Blob, converting to Uint8Array.");
+              modifiedFileData = new Uint8Array(await fileContent.arrayBuffer());
+          } else { throw new Error(`Unexpected content type for output file node at ${outputFilePath}`); }
+      }
+  } catch(lookupError) {
+       const message = (lookupError instanceof Error) ? lookupError.message : String(lookupError);
+       console.error(`Failed to retrieve output file from virtual FS at ${outputFilePath}:`, message);
+       return { success: false, data: undefined, error: `Internal error retrieving output: ${message}. Warnings: ${stderrOutput}`, exitCode: 0 };
+  }
+
+  // Final check
+  if (!modifiedFileData) {
+       console.error(`ExifTool reported success (exit 0), but failed to retrieve valid output file data at ${outputFilePath}.`);
+        return { success: false, data: undefined, error: `Internal error: Output data retrieval failed despite exit code 0. Warnings: ${stderrOutput}`, exitCode: 0 };
+  }
+
+  // 11. Return success with the output data
+  console.log(`[DEBUG] Successfully retrieved output file data from ${outputFilePath}. Size: ${modifiedFileData.byteLength} bytes.`);
+  return {
+    success: true,
+    data: modifiedFileData, // This is the content of the *new* output file
+    warnings: stderrOutput,
+    exitCode: 0,
+  };
+}
+
+export { parseMetadata, writeMetadata };
+export type { ExifToolOptions, ExifToolOutput, ExifToolWriteOptions, ExifToolWriteResult, Binaryfile };


### PR DESCRIPTION
Now, you can write tags using JS Object syntax: 

```
    const tagsToWrite = {
      "XMP-GCamera:MicroVideo": 1, // ExifTool handles numeric values appropriately
      "XMP-GCamera:MicroVideoVersion": 1,
      "XMP-GCamera:MicroVideoOffset": dummyOffset,
      "XMP-GCamera:MicroVideoPresentationTimestampUs": dummyTimestamp,
    };

    const extraArgs = ["-m", "-q"]; // -m: ignore minor errors, -q: quiet
    const options: ExifToolWriteOptions = {
        tags: tagsToWrite, // Pass the TagsObject
        extraArgs: extraArgs,
        configFile: configFileContent
    };

    try {
      console.log("Calling writeMetadata with GCamera options (JSON format tags):", options);
      const result = await writeMetadata(selectedFile, options);
      // handle result 
```